### PR TITLE
[CAP-60] Select Start and Destination

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -11,6 +11,7 @@
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
+            <option value="$PROJECT_DIR$/delivery" />
           </set>
         </option>
         <option name="resolveExternalAnnotations" value="false" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
     defaultConfig {
         applicationId = "minicap.concordia.campusnav"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 33
         versionCode = 1
         versionName = "1.0"
 
@@ -37,6 +37,10 @@ android {
         viewBinding = true
         buildConfig = true
     }
+    testOptions{
+        unitTests.isReturnDefaultValues = true
+        unitTests.isIncludeAndroidResources = true
+    }
 }
 
 dependencies {
@@ -55,4 +59,6 @@ dependencies {
     testImplementation("org.robolectric:robolectric:4.10")
     testImplementation("com.squareup.okhttp3:okhttp:4.9.3")
     testImplementation("com.google.code.gson:gson:2.10.1")
+    testImplementation("org.mockito:mockito-core:5.16.0")
+    testImplementation("org.json:json:20250107")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,10 @@
             android:exported="false"
             android:label="@string/title_activity_maps" />
         <activity
+            android:name=".screens.LocationSearchActivity"
+            android:exported="false"
+            android:label="LocationSearch" />
+        <activity
             android:name=".screens.MainActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/minicap/concordia/campusnav/buildingmanager/ConcordiaBuildingManager.java
+++ b/app/src/main/java/minicap/concordia/campusnav/buildingmanager/ConcordiaBuildingManager.java
@@ -2,6 +2,7 @@ package minicap.concordia.campusnav.buildingmanager;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import minicap.concordia.campusnav.buildingmanager.entities.Building;
 import minicap.concordia.campusnav.buildingmanager.entities.Campus;
@@ -83,6 +84,24 @@ public class ConcordiaBuildingManager {
         }
 
         return finalBuildings;
+    }
+
+    /**
+     * Returns a list of buildings that match (partially or otherwise) the provided name
+     * @param buildingName The name of the building you are looking for
+     * @return List of buildings that match or partially match the searched string
+     */
+    public List<Building> searchBuildingsByName(String buildingName) {
+        ArrayList<Building> foundBuildings = new ArrayList<>();
+        String searchName = buildingName.toLowerCase();
+
+        for(Building building: buildings.values()) {
+            if(building.getBuildingName().toLowerCase().contains(searchName)) {
+                foundBuildings.add(building);
+            }
+        }
+
+        return foundBuildings;
     }
 
     /**

--- a/app/src/main/java/minicap/concordia/campusnav/map/InternalGoogleMaps.java
+++ b/app/src/main/java/minicap/concordia/campusnav/map/InternalGoogleMaps.java
@@ -101,6 +101,10 @@ public class InternalGoogleMaps extends AbstractMap{
         }
     }
 
+    public void setOnMapClickListener(GoogleMap.OnMapClickListener listener) {
+        mMap.setOnMapClickListener(listener);
+    }
+
     public void parseRoutePolylineAndDisplay(JSONArray steps) throws JSONException {
         // Looping trough steps to display on UI
         for (int i = 0; i < steps.length(); i++) {

--- a/app/src/main/java/minicap/concordia/campusnav/map/InternalGoogleMaps.java
+++ b/app/src/main/java/minicap/concordia/campusnav/map/InternalGoogleMaps.java
@@ -5,9 +5,11 @@ import android.util.Log;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.Dot;
 import com.google.android.gms.maps.model.Gap;
 import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.PolygonOptions;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.android.gms.maps.model.Polyline;
@@ -27,6 +29,8 @@ public class InternalGoogleMaps extends AbstractMap{
     private final float defaultZoom = 18;
     private final GoogleMap mMap;
     private List<Polyline> polylines = new ArrayList<>();
+
+    private List<Marker> markers = new ArrayList<>();
 
     public InternalGoogleMaps(GoogleMap map){
         mMap = map;
@@ -49,6 +53,10 @@ public class InternalGoogleMaps extends AbstractMap{
         //Google maps does not have floors, so do nothing
     }
 
+    /**
+     * Add polygons to the map (used for building shapes)
+     * @param options A list of PolygonOptions to be added to the map
+     */
     public void addPolygons(List<PolygonOptions> options) {
         for (PolygonOptions polygonOptions : options){
             mMap.addPolygon(polygonOptions);
@@ -56,19 +64,62 @@ public class InternalGoogleMaps extends AbstractMap{
     }
 
     /**
-     * Adds marker to the googleMaps
-     * @param markerOptions MarkerOptions
+     * Adds a marker to the map based on position with the title and color given, with the option to clear other markers
+     * @param position The position of the marker
+     * @param title The title used for the marker
+     * @param color The color of the marker (use BitmapDescriptorFactory to get the color float)
+     * @param clearOtherMarkers Flag to indicate whether to clear other markers on the map
      */
-    public void addMarker(MarkerOptions markerOptions){
-        mMap.addMarker(markerOptions);
-    }
-
-    public void addMarker(MarkerOptions markerOptions, boolean clearOtherMarkers) {
+    public void addMarker(LatLng position, String title, float color, boolean clearOtherMarkers){
         if(clearOtherMarkers) {
-            mMap.clear();
+            clearAllMarkers();
         }
 
-        addMarker(markerOptions);
+        MarkerOptions newMarker = new MarkerOptions()
+                                        .icon(BitmapDescriptorFactory.defaultMarker(color))
+                                        .position(position)
+                                        .title(title);
+        markers.add(mMap.addMarker(newMarker));
+    }
+
+    /**
+     * Adds a marker to the map using the default color, does not clear other markers
+     * @param position The position of the marker
+     * @param title The title of the marker
+     */
+    public void addMarker(LatLng position, String title) {
+        addMarker(position, title, BitmapDescriptorFactory.HUE_RED, false);
+    }
+
+    /**
+     * Adds a marker to the map, does not clear other markers
+     * @param position The position of the marker
+     * @param title The title of the marker
+     * @param color The color of the marker (use BitmapDescriptorFactory to get the color float)
+     */
+    public void addMarker(LatLng position, String title, float color) {
+        addMarker(position, title, color, false);
+    }
+
+    /**
+     * Adds a marker to the map, clearing other markers if desired
+     * @param position The position of the marker
+     * @param title The title of the marker
+     * @param clearOtherMarkers Flag indicating whether to clear other markers
+     */
+    public void addMarker(LatLng position, String title, boolean clearOtherMarkers) {
+        addMarker(position, title, BitmapDescriptorFactory.HUE_RED, clearOtherMarkers);
+    }
+
+    /**
+     * Clears all the current markers from the map
+     */
+    public void clearAllMarkers() {
+        for (Iterator<Marker> allMarkers = markers.iterator(); allMarkers.hasNext();) {
+            Marker cur = allMarkers.next();
+            cur.remove();
+            allMarkers.remove();
+        }
     }
 
     /**
@@ -80,7 +131,7 @@ public class InternalGoogleMaps extends AbstractMap{
     }
 
     /**
-     * Removes All polylines
+     * Removes all polylines from the map (used for route)
      */
     public void clearPolyLines(){
         for (Iterator<Polyline> it = polylines.iterator(); it.hasNext();) {
@@ -101,10 +152,19 @@ public class InternalGoogleMaps extends AbstractMap{
         }
     }
 
+    /**
+     * Sets an onClick listener for the map
+     * @param listener The listener to be set
+     */
     public void setOnMapClickListener(GoogleMap.OnMapClickListener listener) {
         mMap.setOnMapClickListener(listener);
     }
 
+    /**
+     * Parses the JSONArray given by the Routes API to create a polyline
+     * @param steps The array of steps in the line
+     * @throws JSONException Thrown when there is an error parsing the JSON
+     */
     public void parseRoutePolylineAndDisplay(JSONArray steps) throws JSONException {
         // Looping trough steps to display on UI
         for (int i = 0; i < steps.length(); i++) {
@@ -137,15 +197,19 @@ public class InternalGoogleMaps extends AbstractMap{
                 } else if ("SUBWAY".equalsIgnoreCase(vehicleType) || "METRO".equalsIgnoreCase(vehicleType)) {
                     switch (transitLineName) {
                         case "Ligne Verte":
+                        case "Verte":
                             polylineOptions.color(Color.parseColor("#008000"));
                             break;
                         case "Ligne Orange":
+                        case "Orange":
                             polylineOptions.color(Color.parseColor("#FFA500"));
                             break;
                         case "Ligne Jaune":
+                        case "Jaune":
                             polylineOptions.color(Color.parseColor("#FFD700"));
                             break;
                         case "Ligne Bleu":
+                        case "Blue":
                             polylineOptions.color(Color.parseColor("#0000FF"));
                             break;
                         default:

--- a/app/src/main/java/minicap/concordia/campusnav/map/InternalGoogleMaps.java
+++ b/app/src/main/java/minicap/concordia/campusnav/map/InternalGoogleMaps.java
@@ -1,17 +1,25 @@
 package minicap.concordia.campusnav.map;
 
+import android.graphics.Color;
 import android.util.Log;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.Dot;
+import com.google.android.gms.maps.model.Gap;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.PolygonOptions;
-import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.android.gms.maps.model.Polyline;
 import com.google.android.gms.maps.model.PolylineOptions;
+import com.google.maps.android.PolyUtil;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -33,7 +41,7 @@ public class InternalGoogleMaps extends AbstractMap{
     public void centerOnCoordinates(double latitude, double longitude){
         LatLng concordia = new LatLng(latitude, longitude);
 
-        mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(concordia, defaultZoom));
+        mMap.animateCamera(CameraUpdateFactory.newLatLngZoom(concordia, defaultZoom));
     }
 
     @Override
@@ -54,6 +62,15 @@ public class InternalGoogleMaps extends AbstractMap{
     public void addMarker(MarkerOptions markerOptions){
         mMap.addMarker(markerOptions);
     }
+
+    public void addMarker(MarkerOptions markerOptions, boolean clearOtherMarkers) {
+        if(clearOtherMarkers) {
+            mMap.clear();
+        }
+
+        addMarker(markerOptions);
+    }
+
     /**
      * Adds PolyLine to the googleMaps
      * @param options PolylineOptions
@@ -72,20 +89,6 @@ public class InternalGoogleMaps extends AbstractMap{
             it.remove();
         }
     }
-    public void animateCameraToLocation(LatLng location, float zoom) {
-        mMap.animateCamera(CameraUpdateFactory.newLatLngZoom(location, zoom));
-    }
-
-    public Marker updateCampusMarker(Marker marker, LatLng campus, boolean showSGW) {
-        String campusTitle = showSGW ? "Loyola Campus" : "SGW Campus";
-        if (marker != null) {
-            marker.setPosition(campus);
-            marker.setTitle(campusTitle);
-            return marker;
-        } else {
-            return mMap.addMarker(new MarkerOptions().position(campus).title(campusTitle));
-        }
-    }
 
     @Override
     public boolean toggleLocationTracking(boolean isEnabled) {
@@ -95,6 +98,59 @@ public class InternalGoogleMaps extends AbstractMap{
         } catch (SecurityException e) {
             Log.d("InternalGoogleMaps", "Permissions not granted for location");
             return false;
+        }
+    }
+
+    public void parseRoutePolylineAndDisplay(JSONArray steps) throws JSONException {
+        // Looping trough steps to display on UI
+        for (int i = 0; i < steps.length(); i++) {
+
+            JSONObject step = steps.getJSONObject(i);
+            String travelMode = step.getString("travelMode");
+            JSONObject polylineObject = step.getJSONObject("polyline");
+            String encodedPolyline = polylineObject.getString("encodedPolyline");
+            List<LatLng> stepPoints = PolyUtil.decode(encodedPolyline);
+
+            PolylineOptions polylineOptions = new PolylineOptions()
+                    .addAll(stepPoints)
+                    .width(10);
+
+            //Case where Walking
+            if ("WALK".equals(travelMode)) {
+                polylineOptions.color(Color.BLUE)
+                        .pattern(Arrays.asList(new Dot(), new Gap(10)));
+                //Case where Transit
+            } else if ("TRANSIT".equals(travelMode)) {
+                JSONObject transitDetails = step.getJSONObject("transitDetails");
+                String vehicleType = transitDetails.getJSONObject("transitLine")
+                        .getJSONObject("vehicle")
+                        .getString("type");
+                String transitLineName = transitDetails.getJSONObject("transitLine").getString("name");
+
+                // Set color based on vehicle type
+                if ("BUS".equalsIgnoreCase(vehicleType)) {
+                    polylineOptions.color(Color.parseColor("#000000"));
+                } else if ("SUBWAY".equalsIgnoreCase(vehicleType) || "METRO".equalsIgnoreCase(vehicleType)) {
+                    switch (transitLineName) {
+                        case "Ligne Verte":
+                            polylineOptions.color(Color.parseColor("#008000"));
+                            break;
+                        case "Ligne Orange":
+                            polylineOptions.color(Color.parseColor("#FFA500"));
+                            break;
+                        case "Ligne Jaune":
+                            polylineOptions.color(Color.parseColor("#FFD700"));
+                            break;
+                        case "Ligne Bleu":
+                            polylineOptions.color(Color.parseColor("#0000FF"));
+                        default:
+                            polylineOptions.color(Color.GRAY); // Default in case the name changes
+                            break;
+                    }
+                }
+            }
+
+            addPolyline(polylineOptions);
         }
     }
 }

--- a/app/src/main/java/minicap/concordia/campusnav/map/InternalGoogleMaps.java
+++ b/app/src/main/java/minicap/concordia/campusnav/map/InternalGoogleMaps.java
@@ -200,20 +200,16 @@ public class InternalGoogleMaps extends AbstractMap{
                     polylineOptions.color(Color.parseColor("#000000"));
                 } else if ("SUBWAY".equalsIgnoreCase(vehicleType) || "METRO".equalsIgnoreCase(vehicleType)) {
                     switch (transitLineName) {
-                        case "Ligne Verte":
-                        case "Verte":
+                        case "Ligne Verte", "Verte":
                             polylineOptions.color(Color.parseColor("#008000"));
                             break;
-                        case "Ligne Orange":
-                        case "Orange":
+                        case "Ligne Orange", "Orange":
                             polylineOptions.color(Color.parseColor("#FFA500"));
                             break;
-                        case "Ligne Jaune":
-                        case "Jaune":
+                        case "Ligne Jaune", "Jaune":
                             polylineOptions.color(Color.parseColor("#FFD700"));
                             break;
-                        case "Ligne Bleu":
-                        case "Blue":
+                        case "Ligne Bleu", "Bleu":
                             polylineOptions.color(Color.parseColor("#0000FF"));
                             break;
                         default:

--- a/app/src/main/java/minicap/concordia/campusnav/map/InternalGoogleMaps.java
+++ b/app/src/main/java/minicap/concordia/campusnav/map/InternalGoogleMaps.java
@@ -36,6 +36,10 @@ public class InternalGoogleMaps extends AbstractMap{
         mMap = map;
     }
 
+    public List<Polyline> getPolylines() {
+        return polylines;
+    }
+
     @Override
     public void centerOnCoordinates(float latitude, float longitude) {
         centerOnCoordinates((double)latitude, (double)longitude);

--- a/app/src/main/java/minicap/concordia/campusnav/map/InternalGoogleMaps.java
+++ b/app/src/main/java/minicap/concordia/campusnav/map/InternalGoogleMaps.java
@@ -147,6 +147,7 @@ public class InternalGoogleMaps extends AbstractMap{
                             break;
                         case "Ligne Bleu":
                             polylineOptions.color(Color.parseColor("#0000FF"));
+                            break;
                         default:
                             polylineOptions.color(Color.GRAY); // Default in case the name changes
                             break;

--- a/app/src/main/java/minicap/concordia/campusnav/screens/LocationSearchActivity.java
+++ b/app/src/main/java/minicap/concordia/campusnav/screens/LocationSearchActivity.java
@@ -5,6 +5,7 @@ import static android.view.View.VISIBLE;
 
 import android.annotation.SuppressLint;
 import android.content.Intent;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -187,6 +188,7 @@ class LocationAdapter extends RecyclerView.Adapter<LocationAdapter.ViewHolder> {
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         Building cur = filteredLocations.get(position);
         holder.locationText.setText(cur.getBuildingName());
+        holder.locationText.setTextColor(Color.parseColor("#FFFFFF"));
         holder.itemView.setOnClickListener(v -> {
             if(onClickListener != null) {
                 onClickListener.onClick(cur.getBuildingName(), cur.getLocation()[0], cur.getLocation()[1]);

--- a/app/src/main/java/minicap/concordia/campusnav/screens/LocationSearchActivity.java
+++ b/app/src/main/java/minicap/concordia/campusnav/screens/LocationSearchActivity.java
@@ -102,12 +102,12 @@ public class LocationSearchActivity extends AppCompatActivity {
         searchInput.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-
+                //Not needed
             }
 
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
-
+                //Not needed
             }
 
             @Override
@@ -120,8 +120,6 @@ public class LocationSearchActivity extends AppCompatActivity {
 
                 //may be unnecessary
                 if(s.toString().contains("\n")) {
-                    int start = s.length() - 3;
-                    int end = s.length() - 2;
                     s.delete(s.length() - 3, s.length() - 1);
                 }
                 adapter.filter(s.toString());

--- a/app/src/main/java/minicap/concordia/campusnav/screens/MainActivity.java
+++ b/app/src/main/java/minicap/concordia/campusnav/screens/MainActivity.java
@@ -48,7 +48,9 @@ public class MainActivity extends AppCompatActivity {
                 i.putExtra(MapsActivity.KEY_STARTING_LAT, coords.latitude);
                 i.putExtra(MapsActivity.KEY_STARTING_LNG, coords.longitude);
                 i.putExtra(MapsActivity.KEY_CAMPUS_NOT_SELECTED, "LOY");
-                startActivity(i);            }
+                i.putExtra(MapsActivity.KEY_SHOW_SGW, true);
+                startActivity(i);
+            }
         });
 
         Button loyCampusBtn = (Button)findViewById(R.id.viewLoyCampusButton);
@@ -67,6 +69,7 @@ public class MainActivity extends AppCompatActivity {
                 i.putExtra(MapsActivity.KEY_STARTING_LAT, coords.latitude);
                 i.putExtra(MapsActivity.KEY_STARTING_LNG, coords.longitude);
                 i.putExtra(MapsActivity.KEY_CAMPUS_NOT_SELECTED, "SGW");
+                i.putExtra(MapsActivity.KEY_SHOW_SGW, false);
                 startActivity(i);
             }
         });

--- a/app/src/main/java/minicap/concordia/campusnav/screens/MapsActivity.java
+++ b/app/src/main/java/minicap/concordia/campusnav/screens/MapsActivity.java
@@ -94,6 +94,8 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
     private ImageButton carButton;
     private ImageButton transitButton;
 
+    private BottomSheetBehavior<LinearLayout> bottomSheetBehavior;
+
     private FusedLocationProviderClient fusedLocationClient;
 
     private String travelMode = "DRIVE";
@@ -123,7 +125,7 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
         setContentView(binding.getRoot());
 
         LinearLayout bottomSheet = findViewById(R.id.bottom_sheet);
-        BottomSheetBehavior<LinearLayout> bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet);
+        bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet);
 
         int peekHeightPx = (int) (32 * getResources().getDisplayMetrics().density);
         bottomSheetBehavior.setPeekHeight(peekHeightPx); // Set peek height
@@ -238,6 +240,8 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
                             searchText.clearFocus();
                             destinationEditText.clearFocus();
                             yourLocationEditText.clearFocus();
+
+                            bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
                         });
                     }
                 });

--- a/app/src/main/java/minicap/concordia/campusnav/screens/MapsActivity.java
+++ b/app/src/main/java/minicap/concordia/campusnav/screens/MapsActivity.java
@@ -282,7 +282,7 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
         showSGW = !showSGW;
 
         // getting the new campus location
-        CampusName wantedCampus = showSGW ? CampusName.LOYOLA : CampusName.SGW;
+        CampusName wantedCampus = showSGW ? CampusName.SGW : CampusName.LOYOLA;
         Campus curCampus = buildingManager.getCampus(wantedCampus);
         LatLng campusCoords = new LatLng(curCampus.getLocation()[0], curCampus.getLocation()[1]);
 

--- a/app/src/main/java/minicap/concordia/campusnav/screens/MapsActivity.java
+++ b/app/src/main/java/minicap/concordia/campusnav/screens/MapsActivity.java
@@ -57,6 +57,8 @@ import minicap.concordia.campusnav.map.InternalGoogleMaps;
 
 public class MapsActivity extends FragmentActivity implements OnMapReadyCallback, FetchPathTask.OnRouteFetchedListener{
 
+    private final String MAPS_ACTIVITY_TAG = "MapsActivity";
+
     public static final String KEY_STARTING_LAT = "starting_lat";
     public static final String KEY_STARTING_LNG = "starting_lng";
     public static final String KEY_CAMPUS_NOT_SELECTED = "campus_not_selected";
@@ -210,12 +212,12 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
                         if(result.getResultCode() == LocationSearchActivity.RESULT_OK) {
                             Intent intent = result.getData();
                             if(intent == null) {
-                                Log.e("MapsActivity", "Error while reading results from search, no intent returned");
+                                Log.e(MAPS_ACTIVITY_TAG, "Error while reading results from search, no intent returned");
                                 return;
                             }
                             Bundle returnData = intent.getExtras();
                             if(returnData == null) {
-                                Log.e("MapsActivity", "Error while reading results from search, no data was returned");
+                                Log.e(MAPS_ACTIVITY_TAG, "Error while reading results from search, no data was returned");
                                 return;
                             }
 
@@ -256,7 +258,7 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
     }
 
     private void setStartingPoint(boolean useCurrentLocation, String locationString, float lat, float lng) {
-        Log.d("MapsActivity", "Set starting location to: " + locationString + " with coords: (" + lat + ", " + lng + "), is current location: " + useCurrentLocation);
+        Log.d(MAPS_ACTIVITY_TAG, "Set starting location to: " + locationString + " with coords: (" + lat + ", " + lng + "), is current location: " + useCurrentLocation);
 
         if(useCurrentLocation) {
             startingPoint = getUserLocationPath();
@@ -271,7 +273,7 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
     }
 
     private void setDestination(String locationString, float lat, float lng) {
-        Log.d("MapsActivity", "Set starting location to: " + locationString + " with coords: (" + lat + ", " + lng + ")");
+        Log.d(MAPS_ACTIVITY_TAG, "Set starting location to: " + locationString + " with coords: (" + lat + ", " + lng + ")");
 
         destination = new LatLng(lat, lng);
         destinationEditText.setText(locationString);
@@ -429,9 +431,9 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
         }
     }
 
-    //TODO: It would be best if this was handled by the map class
+    //Note: It would be best if this was handled by the map class
     /**
-     * This Method generates the GoogleAPI URL and invokes FetchPathTask
+     * This handles the calls to the map to create the route
      * @param origin LatLng
      * @param destination LatLng
      */
@@ -458,7 +460,7 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
         bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
     }
 
-    //TODO: It would be best if this is handled by the map class
+    //Note: It would be best if this is handled by the map class
     /**
      * Will add the route to the Map
      * Invoked when the route is fetched by the Google API

--- a/app/src/main/java/minicap/concordia/campusnav/screens/MapsActivity.java
+++ b/app/src/main/java/minicap/concordia/campusnav/screens/MapsActivity.java
@@ -219,7 +219,9 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
         searchText.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-                launchSearchActivity("", false);
+                if(hasFocus) {
+                    launchSearchActivity("", false);
+                }
             }
         });
 
@@ -240,21 +242,26 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
                             }
 
                             boolean isDestination = returnData.getBoolean(LocationSearchActivity.KEY_RETURN_BOOL_IS_DESTINATION);
+                            float lat = returnData.getFloat(LocationSearchActivity.KEY_RETURN_CHOSEN_LAT);
+                            float lng = returnData.getFloat(LocationSearchActivity.KEY_RETURN_CHOSEN_LNG);
                             if(isDestination) {
                                 String returnedLocation = returnData.getString(LocationSearchActivity.KEY_RETURN_CHOSEN_LOCATION);
-                                setDestination(returnedLocation);
+                                setDestination(returnedLocation, lat, lng);
                             }
                             else {
                                 boolean useCurrentLocation = returnData.getBoolean(LocationSearchActivity.KEY_RETURN_BOOL_CURRENT_LOCATION);
                                 if(useCurrentLocation) {
-                                    setStartingPoint(true, "");
+                                    setStartingPoint(true, "", lat, lng);
                                 }
                                 else {
                                     String returnedLocation = returnData.getString(LocationSearchActivity.KEY_RETURN_CHOSEN_LOCATION);
-                                    setStartingPoint(false, returnedLocation);
+                                    setStartingPoint(false, returnedLocation, lat, lng);
                                 }
                             }
                         }
+                        runOnUiThread(() -> {
+                            searchText.clearFocus();
+                        });
                     }
                 });
     }
@@ -267,12 +274,12 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
         searchLocationLauncher.launch(i);
     }
 
-    private void setStartingPoint(boolean useCurrentLocation, String locationString) {
-        Toast.makeText(this, "Setting the starting location to: " + locationString + ", Use current location: " + useCurrentLocation, Toast.LENGTH_SHORT).show();
+    private void setStartingPoint(boolean useCurrentLocation, String locationString, float lat, float lng) {
+        Log.d("MapsActivity", "Set starting location to: " + locationString + " with coords: (" + lat + ", " + lng + "), is current location: " + useCurrentLocation);
     }
 
-    private void setDestination(String locationString) {
-        Toast.makeText(this, "Setting the destination to: " + locationString, Toast.LENGTH_SHORT).show();
+    private void setDestination(String locationString, float lat, float lng) {
+        Log.d("MapsActivity", "Set starting location to: " + locationString + " with coords: (" + lat + ", " + lng + ")");
     }
 
     private void toggleCampus(){

--- a/app/src/main/java/minicap/concordia/campusnav/screens/MapsActivity.java
+++ b/app/src/main/java/minicap/concordia/campusnav/screens/MapsActivity.java
@@ -8,6 +8,7 @@ import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentActivity;
@@ -240,8 +241,6 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
                             searchText.clearFocus();
                             destinationEditText.clearFocus();
                             yourLocationEditText.clearFocus();
-
-                            bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
                         });
                     }
                 });
@@ -353,6 +352,17 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
         gMapController.addPolygons(CampusBuildingShapes.getSgwBuildingCoordinates());
         gMapController.addPolygons(CampusBuildingShapes.getLoyolaBuildingCoordinates());
 
+        gMapController.setOnMapClickListener(new GoogleMap.OnMapClickListener() {
+            @Override
+            public void onMapClick(@NonNull LatLng latLng) {
+                String address = getAddressFromLocation(latLng.latitude, latLng.longitude);
+                gMapController.addMarker(new MarkerOptions()
+                        .position(latLng)
+                        .title("Clicked location"));
+                setDestination(address, (float)latLng.latitude, (float)latLng.longitude);
+            }
+        });
+
         //Default starting point is user location
         startingPoint = getUserLocationPath();
 
@@ -444,6 +454,8 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
         gMapController.centerOnCoordinates(origin.latitude,origin.longitude);
 
         new FetchPathTask(this).fetchRoute(origin, destination, travelMode);
+
+        bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
     }
 
     //TODO: It would be best if this is handled by the map class

--- a/app/src/main/res/layout/activity_location_search.xml
+++ b/app/src/main/res/layout/activity_location_search.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/light_burgundy"
@@ -22,9 +23,10 @@
         android:id="@+id/useCurrentLocationButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:backgroundTint="@color/concordia_yellow"
+        android:backgroundTint="@color/light_burgundy"
         android:text="@string/current_location"
-        android:textColor="@color/black" />
+        android:textAlignment="viewStart"
+        android:textColor="@color/white" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/results_recycler_view"

--- a/app/src/main/res/layout/activity_location_search.xml
+++ b/app/src/main/res/layout/activity_location_search.xml
@@ -7,7 +7,7 @@
 
     <!-- Search Input -->
     <EditText
-        android:id="@+id/search_input"
+        android:id="@+id/locationSearch"
         android:layout_width="match_parent"
         android:layout_height="62dp"
         android:background="@android:drawable/editbox_background"
@@ -16,14 +16,14 @@
         android:padding="10dp" />
 
     <!-- Search Button -->
-    <Button
-        android:id="@+id/search_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:text="Search" />
 
     <!-- RecyclerView for results -->
+    <Button
+        android:id="@+id/useCurrentLocationButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/current_location" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/results_recycler_view"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_location_search.xml
+++ b/app/src/main/res/layout/activity_location_search.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/light_burgundy"
     android:orientation="vertical"
     android:padding="16dp">
 
@@ -11,7 +12,6 @@
         android:layout_width="match_parent"
         android:layout_height="62dp"
         android:background="@android:drawable/editbox_background"
-        android:hint="Enter location"
         android:inputType="text"
         android:padding="10dp" />
 
@@ -22,7 +22,9 @@
         android:id="@+id/useCurrentLocationButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/current_location" />
+        android:backgroundTint="@color/concordia_yellow"
+        android:text="@string/current_location"
+        android:textColor="@color/black" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/results_recycler_view"

--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -215,18 +215,12 @@
 
                 <EditText
                     android:id="@+id/yourLocationEditText"
-                    android:layout_width="0dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:hint="Your Location"
-                    android:textColor="@color/black"
-                    android:textColorHint="@color/gray"
-                    android:layout_marginStart="8dp"
-                    android:focusable="false"
-                    android:clickable="false"
-                    android:cursorVisible="false"
-                    android:inputType="none"
-                    android:background="@null" />
+                    android:ems="10"
+                    android:hint="@string/your_location"
+                    android:inputType="text" />
 
                 <ImageView
                     android:layout_width="24dp"
@@ -257,10 +251,15 @@
                     android:src="@drawable/ic_destination"
                     app:tint="@color/black"/>
 
-                <Spinner
-                    android:id="@+id/building_spinner"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
+                <EditText
+                    android:id="@+id/destinationText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:ems="10"
+                    android:hint="@string/your_destination"
+                    android:inputType="text" />
+
             </LinearLayout>
         </androidx.cardview.widget.CardView>
 

--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -160,6 +160,7 @@
                 android:src="@drawable/search_button" />
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/genericSearchField"
                 android:layout_width="213dp"
                 android:layout_height="45dp"
                 android:hint="      Search Area..."

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,7 @@
     <string name="go_to">Go To</string>
     <string name="english">ENG</string>
     <string name="estimated_time">Estimated time: %1$s</string>
+    <string name="current_location">Current Location</string>
+    <string name="destination_search_hint">Choose destination</string>
+    <string name="starting_point_search_hint">Choose starting point</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,9 @@
     <string name="go_to">Go To</string>
     <string name="english">ENG</string>
     <string name="estimated_time">Estimated time: %1$s</string>
-    <string name="current_location">Current Location</string>
+    <string name="current_location">Current location</string>
     <string name="destination_search_hint">Choose destination</string>
     <string name="starting_point_search_hint">Choose starting point</string>
+    <string name="your_location">Your location</string>
+    <string name="your_destination">Your destination</string>
 </resources>

--- a/app/src/test/java/minicap/concordia/campusnav/InternalGoogleMapsTests.java
+++ b/app/src/test/java/minicap/concordia/campusnav/InternalGoogleMapsTests.java
@@ -47,7 +47,7 @@ public class InternalGoogleMapsTests {
 
             Mockito.verify(mapMock).animateCamera(mockUpdate);
         } catch (Exception e) {
-            Assert.assertEquals("Unable to mock the static instance", 0, 1);
+            Assert.fail("Assertion failure or exception during test: " + e.getMessage());
         }
     }
 
@@ -252,7 +252,7 @@ public class InternalGoogleMapsTests {
         }
         catch(JSONException e) {
             //Purposefully fail if there is a parsing exception
-            Assert.assertEquals("Exception while parsing the JSON: " + e.getMessage(), 0,1);
+            Assert.fail("Exception while parsing the JSON: " + e.getMessage());
         }
     }
 
@@ -303,7 +303,7 @@ public class InternalGoogleMapsTests {
         }
         catch(JSONException e) {
             //Purposefully fail if there is a parsing exception
-            Assert.assertEquals("Exception while parsing the JSON: " + e.getMessage(), 0,1);
+            Assert.fail("Exception while parsing the JSON: " + e.getMessage());
         }
     }
 }

--- a/app/src/test/java/minicap/concordia/campusnav/InternalGoogleMapsTests.java
+++ b/app/src/test/java/minicap/concordia/campusnav/InternalGoogleMapsTests.java
@@ -1,0 +1,220 @@
+package minicap.concordia.campusnav;
+
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.Polyline;
+import com.google.android.gms.maps.model.PolylineOptions;
+import com.google.maps.android.PolyUtil;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import minicap.concordia.campusnav.map.InternalGoogleMaps;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InternalGoogleMapsTests {
+
+    @Test
+    public void testAddPolyline() {
+        LatLng firstExpectedPoint = new LatLng(0,0);
+        LatLng secondExpectedPoint = new LatLng(1,1);
+        List<LatLng> expectedPointList = new ArrayList<>();
+        expectedPointList.add(firstExpectedPoint);
+        expectedPointList.add(secondExpectedPoint);
+        PolylineOptions expectedOptions = new PolylineOptions()
+                .add(firstExpectedPoint)
+                .add(secondExpectedPoint);
+
+        Polyline polyLine = Mockito.mock(Polyline.class);
+        Mockito.when(polyLine.getPoints()).thenReturn(expectedPointList);
+        GoogleMap mapMock = Mockito.mock(GoogleMap.class);
+        Mockito.when(mapMock.addPolyline(expectedOptions)).thenReturn(polyLine);
+
+        InternalGoogleMaps igm = new InternalGoogleMaps(mapMock);
+
+        igm.addPolyline(expectedOptions);
+
+        List<Polyline> lines = igm.getPolylines();
+
+        Assert.assertEquals(1, lines.size());
+
+        Polyline actualLine = lines.get(0);
+
+        Assert.assertEquals(polyLine.getPoints().size(), actualLine.getPoints().size());
+        Assert.assertEquals(firstExpectedPoint, actualLine.getPoints().get(0));
+        Assert.assertEquals(secondExpectedPoint, actualLine.getPoints().get(1));
+    }
+
+    @Test
+    public void testAdd2PolylineWithDifferentColors() {
+        //Create the first polyline information
+        int firstExpectedPolylineColor = 1;
+        LatLng firstExpectedPoint = new LatLng(0,0);
+        LatLng secondExpectedPoint = new LatLng(1,1);
+        List<LatLng> firstLineExpectedPointList = new ArrayList<>();
+        firstLineExpectedPointList.add(firstExpectedPoint);
+        firstLineExpectedPointList.add(secondExpectedPoint);
+        PolylineOptions firstLineExpectedOptions = new PolylineOptions()
+                .add(firstExpectedPoint)
+                .add(secondExpectedPoint)
+                .color(firstExpectedPolylineColor);
+
+        Polyline firstPolyline = Mockito.mock(Polyline.class);
+        Mockito.when(firstPolyline.getPoints()).thenReturn(firstLineExpectedPointList);
+        Mockito.when(firstPolyline.getColor()).thenReturn(firstExpectedPolylineColor);
+
+        //Create second polyline information
+        int secondLineExpectedColor = 2;
+        LatLng thirdExpectedPoint = new LatLng(2, 2);
+        LatLng fourthExpectedPoint = new LatLng(3, 3);
+        LatLng fifthExpectedPoint = new LatLng(4, 4);
+        List<LatLng> secondLineExpectedPointList = new ArrayList<>();
+        secondLineExpectedPointList.add(thirdExpectedPoint);
+        secondLineExpectedPointList.add(fourthExpectedPoint);
+        secondLineExpectedPointList.add(fifthExpectedPoint);
+        PolylineOptions secondLineExpectedOptions = new PolylineOptions()
+                .add(thirdExpectedPoint)
+                .add(fourthExpectedPoint)
+                .add(fifthExpectedPoint)
+                .color(secondLineExpectedColor);
+
+        Polyline secondPolyline = Mockito.mock(Polyline.class);
+        Mockito.when(secondPolyline.getColor()).thenReturn(secondLineExpectedColor);
+        Mockito.when(secondPolyline.getPoints()).thenReturn(secondLineExpectedPointList);
+
+        //Create the map mock
+        GoogleMap mapMock = Mockito.mock(GoogleMap.class);
+        Mockito.when(mapMock.addPolyline(firstLineExpectedOptions)).thenReturn(firstPolyline);
+        Mockito.when(mapMock.addPolyline(secondLineExpectedOptions)).thenReturn(secondPolyline);
+
+        //Act
+        InternalGoogleMaps igm = new InternalGoogleMaps(mapMock);
+
+        igm.addPolyline(firstLineExpectedOptions);
+        igm.addPolyline(secondLineExpectedOptions);
+
+        //Assert
+        List<Polyline> lines = igm.getPolylines();
+
+        Assert.assertEquals(2, lines.size());
+
+        //First polyline tests
+        Polyline actualFirstLine = lines.get(0);
+
+        Assert.assertEquals(firstLineExpectedPointList.size(), actualFirstLine.getPoints().size());
+        Assert.assertEquals(firstExpectedPoint, actualFirstLine.getPoints().get(0));
+        Assert.assertEquals(secondExpectedPoint, actualFirstLine.getPoints().get(1));
+        Assert.assertEquals(firstExpectedPolylineColor, actualFirstLine.getColor());
+
+        //Second polyline tests
+        Polyline actualSecondLine = lines.get(1);
+        Assert.assertEquals(secondLineExpectedPointList.size(), actualSecondLine.getPoints().size());
+        Assert.assertEquals(thirdExpectedPoint, actualSecondLine.getPoints().get(0));
+        Assert.assertEquals(fourthExpectedPoint, actualSecondLine.getPoints().get(1));
+        Assert.assertEquals(fifthExpectedPoint, actualSecondLine.getPoints().get(2));
+        Assert.assertEquals(secondLineExpectedColor, actualSecondLine.getColor());
+    }
+
+    @Test
+    public void testPolylineParseAndDisplayPath_ReturnsAPolyline() {
+        int expectedLinesGenerated = 1;
+        LatLng firstExpectedPoint = new LatLng(0,0);
+        LatLng secondExpectedPoint = new LatLng(1, 1);
+        List<LatLng> expectedPointList = new ArrayList<>();
+        expectedPointList.add(firstExpectedPoint);
+        expectedPointList.add(secondExpectedPoint);
+
+        String encodedLine = PolyUtil.encode(expectedPointList);
+
+        String jsonResponse = "{\n" +
+                "    \"test\" : [\n" +
+                "        {\n" +
+                "            \"travelMode\": \"WALK\",\n" +
+                "            \"polyline\": {\n" +
+                "                \"encodedPolyline\": \"" + encodedLine + "\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    ]\n" +
+                "}";
+
+
+        GoogleMap mapMock = Mockito.mock(GoogleMap.class);
+        InternalGoogleMaps igm = new InternalGoogleMaps(mapMock);
+
+        try {
+            JSONObject jsonObject = new JSONObject(jsonResponse);
+            JSONArray arr = jsonObject.getJSONArray("test");
+
+            igm.parseRoutePolylineAndDisplay(arr);
+
+            List<Polyline> actualLines = igm.getPolylines();
+
+            //All we can check is that a polyline was inserted, there's no way to mock the internalGoogleMaps without defeating the point of the test
+            Assert.assertEquals(expectedLinesGenerated, actualLines.size());
+        }
+        catch(JSONException e) {
+            //Purposefully fail if there is a parsing exception
+            Assert.assertEquals("Exception while parsing the JSON: " + e.getMessage(), 0,1);
+        }
+    }
+
+    @Test
+    public void testPolylineParseAndDisplayPath_ReturnsPolylineTransit() {
+        int expectedLinesGenerated = 1;
+        LatLng firstExpectedPoint = new LatLng(0,0);
+        LatLng secondExpectedPoint = new LatLng(1, 1);
+        List<LatLng> expectedPointList = new ArrayList<>();
+        expectedPointList.add(firstExpectedPoint);
+        expectedPointList.add(secondExpectedPoint);
+
+        String encodedLine = PolyUtil.encode(expectedPointList);
+
+        String jsonResponse = "{\n" +
+                "    \"steps\" : [\n" +
+                "        {\n" +
+                "            \"travelMode\": \"WALK\",\n" +
+                "            \"polyline\": {\n" +
+                "                \"encodedPolyline\": \"" + encodedLine + "\"\n" +
+                "            },\n" +
+                "            \"transitDetails\": {\n" +
+                "                \"transitLine\": {\n" +
+                "                    \"vehicle\":{\n" +
+                "                        \"type\": \"BUS/SUBWAY\"\n" +
+                "                    },\n" +
+                "                    \"name\": \"Ligne Verte\"\n" +
+                "                }\n" +
+                "            }\n" +
+                "        }\n" +
+                "    ]\n" +
+                "}";
+
+
+        GoogleMap mapMock = Mockito.mock(GoogleMap.class);
+        InternalGoogleMaps igm = new InternalGoogleMaps(mapMock);
+
+        try {
+            JSONObject jsonObject = new JSONObject(jsonResponse);
+            JSONArray arr = jsonObject.getJSONArray("steps");
+
+            igm.parseRoutePolylineAndDisplay(arr);
+
+            List<Polyline> actualLines = igm.getPolylines();
+
+            //All we can check is that a polyline was inserted, there's no way to mock the internalGoogleMaps without defeating the point of the test
+            Assert.assertEquals(expectedLinesGenerated, actualLines.size());
+        }
+        catch(JSONException e) {
+            //Purposefully fail if there is a parsing exception
+            Assert.assertEquals("Exception while parsing the JSON: " + e.getMessage(), 0,1);
+        }
+    }
+}


### PR DESCRIPTION
### Goal
The purpose of these changes is to enable the ability to choose a starting point and a destination using the UI that was created. It also allows the user to edit their start/destination and will update the path generated automatically.

## Key features
- A new screen that is used for location searching. Currently, it displays a list of the available buildings to choose from and the user must make a selection from among the list. There is also a search field that allows the user to filter the list. This can be expanded in the future to do more generic searches
- Once a user clicks on the search bar (or starting point/destination in the menu under), this new screen opens and allows the user to choose from among the list
- Clicking on the map will also create a route for the user now
- If the user searches for a starting point, the option to use current location is also available

## UI

**Location search page for destination**
![image](https://github.com/user-attachments/assets/e739e842-c1e7-477a-b0ae-e65547e9aba5)

**Location search page for Starting point**
![image](https://github.com/user-attachments/assets/b570f177-ab7d-45a9-a634-40cd8d819186)

## Comments
- There is a good amount of refactoring that was done as part of this pull request in order to follow best software engineering practices
- Since the location search page is new, there is not actually a mockup for it, once one is created, a new work item to update this page will also be created
- There is a menu on the map that display start location and destination, it now pops up when a new destination is selected
- The RecyclerView that is used to display the location items is generic and is provided by default in Android. In the future (when a mockup is created) this will likely need an "item" component of its own

## Issues
- There are no tests that were created for this, these will have to be implemented in the future with another work item since the functionality is desperately needed. Of course, I am not opposed to trying to test this either.
- There is some functionality that I would have liked to refactor into the map class, but that specific piece of code touches the estimated time and it cannot be moved at the moment without a larger refactoring that is not worth it for this pull request

## Food for thought:
- The search bar at the top is used to set a destination, but we have a menu that pops up that effectively offers the same thing, I'm wondering if the search bar should disappear once that menu is opened and reappear when it's closed
- There is currently no way to just "Clear" the start and destination, if there is spare time we can add this
- The menu for showing directions is directly coupled with the maps activity and I can't help but wonder if it should be it's own layout file and we inflate it once a destination is selected (instead of just having it hidden on the page)
- Two line starting locations/destinations hide the estimated time, whoops
