### PR TITLE
[Issue-52] Shuttle Bus Schedule Changes (UT)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:value="37758349959-7eh7pjvbrjaqov5nd412d2l0ml7fdkul.apps.googleusercontent.com" />
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="${MAPS_API_KEY}" />
+            android:value="AIzaSyDn1GsaPLhpzy1dtOrg7Ifeb9azhfJwRWo" />
         <meta-data
             android:name="com.google.android.gms.auth.WEB_CLIENT_ID"
             android:value="${WEB_CLIENT_ID}" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:value="37758349959-7eh7pjvbrjaqov5nd412d2l0ml7fdkul.apps.googleusercontent.com" />
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyDn1GsaPLhpzy1dtOrg7Ifeb9azhfJwRWo" />
+            android:value="${MAPS_API_KEY}" />
         <meta-data
             android:name="com.google.android.gms.auth.WEB_CLIENT_ID"
             android:value="${WEB_CLIENT_ID}" />

--- a/app/src/main/java/minicap/concordia/campusnav/components/ShuttleBusScheduleFragment.kt
+++ b/app/src/main/java/minicap/concordia/campusnav/components/ShuttleBusScheduleFragment.kt
@@ -40,18 +40,30 @@ class ShuttleBusScheduleFragment : BottomSheetDialogFragment() {
         val loyFridayButton: Button = binding.root.findViewById(R.id.loyFridayButton)
 
         sgwMonThursButton.setOnClickListener {
+            sgwMonThursButton.isSelected = true
+            sgwFridayButton.isSelected = false
+
             filterSchedule("SGW", "Monday-Thursday")
         }
 
         sgwFridayButton.setOnClickListener {
+            sgwMonThursButton.isSelected = false
+            sgwFridayButton.isSelected = true
+
             filterSchedule("SGW", "Friday")
         }
 
         loyMonThursButton.setOnClickListener {
+            loyMonThursButton.isSelected = true
+            loyFridayButton.isSelected = false
+
             filterSchedule("Loyola", "Monday-Thursday")
         }
 
         loyFridayButton.setOnClickListener {
+            loyMonThursButton.isSelected = false
+            loyFridayButton.isSelected = true
+
             filterSchedule("Loyola", "Friday")
         }
 

--- a/app/src/main/java/minicap/concordia/campusnav/components/ShuttleBusScheduleFragment.kt
+++ b/app/src/main/java/minicap/concordia/campusnav/components/ShuttleBusScheduleFragment.kt
@@ -150,7 +150,7 @@ class ShuttleBusScheduleFragment : BottomSheetDialogFragment() {
                     val backgroundColor = when {
                         timeDate == null -> ContextCompat.getColor(requireContext(),R.color.white)// Past times
                         timeDate < currentTime -> ContextCompat.getColor(requireContext(),R.color.gray)// Past times
-                        timeDate == sortedTimes.getOrNull(0)  -> ContextCompat.getColor(requireContext(),R.color.light_burgundy) // Current time
+                        timeDate == sortedTimes.getOrNull(0)  -> ContextCompat.getColor(requireContext(),R.color.pink) // Current time
                         timeDate == sortedTimes.getOrNull(1) -> ContextCompat.getColor(requireContext(),R.color.yellow) // Upcoming time
                         else -> ContextCompat.getColor(requireContext(),R.color.white) // Default
                     }

--- a/app/src/main/res/drawable/shuttle_time_background.xml
+++ b/app/src/main/res/drawable/shuttle_time_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white" />
+    <stroke android:color="@color/black" android:width="2dp"/>
+    <padding android:left="4dp" android:top="4dp" android:right="4dp" android:bottom="4dp"/>
+</shape>

--- a/app/src/main/res/layout/shuttle_bus_schedule.xml
+++ b/app/src/main/res/layout/shuttle_bus_schedule.xml
@@ -119,13 +119,13 @@
             <GridLayout
                 android:id="@+id/sgwGridLayout"
                 android:layout_width="match_parent"
-                android:layout_height="215dp"
+                android:layout_height="wrap_content"
                 android:layout_marginTop="20dp"
                 android:background="@color/white"
-                android:columnCount="5"
+                android:columnCount="6"
                 android:orientation="horizontal"
-                android:padding="10dp"
-                android:rowCount="6" />
+                android:rowCount="6"
+                android:useDefaultMargins="false"/>
         </LinearLayout>
 
         <!-- LOY Departures -->
@@ -197,13 +197,13 @@
             <GridLayout
                 android:id="@+id/loyGridLayout"
                 android:layout_width="match_parent"
-                android:layout_height="215dp"
+                android:layout_height="wrap_content"
                 android:layout_marginTop="20dp"
                 android:background="@color/white"
-                android:columnCount="5"
+                android:columnCount="6"
                 android:orientation="horizontal"
-                android:padding="10dp"
-                android:rowCount="6" />
+                android:rowCount="6"
+                android:useDefaultMargins="false"/>
         </LinearLayout>
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/shuttle_bus_schedule.xml
+++ b/app/src/main/res/layout/shuttle_bus_schedule.xml
@@ -62,6 +62,15 @@
                 android:layout_marginTop="10dp"
                 android:background="@color/yellow" />
 
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="SGW to LOY"
+                android:textColor="@color/yellow"
+                android:textSize="19sp"
+                android:textStyle="bold"
+                android:layout_marginTop="15dp"/>
+
             <!-- SGW Departures -->
             <!-- Grid Timetable -->
             <LinearLayout
@@ -110,7 +119,7 @@
             <GridLayout
                 android:id="@+id/sgwGridLayout"
                 android:layout_width="match_parent"
-                android:layout_height="249dp"
+                android:layout_height="215dp"
                 android:layout_marginTop="20dp"
                 android:background="@color/white"
                 android:columnCount="5"
@@ -119,65 +128,82 @@
                 android:rowCount="6" />
         </LinearLayout>
 
-        <!-- Separator -->
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="2dp"
-            android:layout_marginTop="20dp"
-            android:background="@color/yellow" />
-
         <!-- LOY Departures -->
-        <!-- Grid Timetable -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="5dp"
-            android:layout_marginTop="15dp"
-            android:orientation="horizontal">
+            android:gravity="center"
+            android:orientation="vertical">
+
+            <!-- Separator -->
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="2dp"
+                android:layout_marginTop="20dp"
+                android:background="@color/yellow" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="10dp"
-                android:text="LOY Depatures"
-                android:textColor="@color/white"
+                android:text="LOY to SGW"
+                android:textColor="@color/yellow"
                 android:textSize="19sp"
-                android:textStyle="bold" />
+                android:textStyle="bold"
+                android:layout_marginTop="15dp"/>
 
-            <Button
-                android:id="@+id/loyMonThursButton"
-                android:layout_width="102dp"
-                android:layout_height="36dp"
-                android:layout_marginLeft="5dp"
-                android:layout_marginRight="5dp"
-                android:background="@drawable/button_selector"
-                android:clickable="true"
-                android:focusable="true"
-                android:text="Mon-Thurs"
-                android:textColor="@color/black" />
 
-            <Button
-                android:id="@+id/loyFridayButton"
-                android:layout_width="102dp"
-                android:layout_height="36dp"
+            <!-- Grid Timetable -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_marginLeft="5dp"
-                android:layout_marginRight="5dp"
-                android:background="@drawable/button_selector"
-                android:clickable="true"
-                android:focusable="true"
-                android:text="Friday"
-                android:textColor="@color/black" />
+                android:layout_marginTop="15dp"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="10dp"
+                    android:text="LOY Depatures"
+                    android:textColor="@color/white"
+                    android:textSize="19sp"
+                    android:textStyle="bold" />
+
+                <Button
+                    android:id="@+id/loyMonThursButton"
+                    android:layout_width="102dp"
+                    android:layout_height="36dp"
+                    android:layout_marginLeft="5dp"
+                    android:layout_marginRight="5dp"
+                    android:background="@drawable/button_selector"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:text="Mon-Thurs"
+                    android:textColor="@color/black" />
+
+                <Button
+                    android:id="@+id/loyFridayButton"
+                    android:layout_width="102dp"
+                    android:layout_height="36dp"
+                    android:layout_marginLeft="5dp"
+                    android:layout_marginRight="5dp"
+                    android:background="@drawable/button_selector"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:text="Friday"
+                    android:textColor="@color/black" />
+            </LinearLayout>
+
+            <GridLayout
+                android:id="@+id/loyGridLayout"
+                android:layout_width="match_parent"
+                android:layout_height="215dp"
+                android:layout_marginTop="20dp"
+                android:background="@color/white"
+                android:columnCount="5"
+                android:orientation="horizontal"
+                android:padding="10dp"
+                android:rowCount="6" />
         </LinearLayout>
-
-        <GridLayout
-            android:id="@+id/loyGridLayout"
-            android:layout_width="match_parent"
-            android:layout_height="249dp"
-            android:layout_marginTop="20dp"
-            android:background="@color/white"
-            android:columnCount="5"
-            android:orientation="horizontal"
-            android:padding="10dp"
-            android:rowCount="6" />
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,4 +8,5 @@
     <color name="yellow">#E3C573</color>
     <color name="gray">#808080</color>
     <color name="light_burgundy">#9F3353</color>
+    <color name="pink">#C58598</color>
 </resources>


### PR DESCRIPTION
### Purpose: 
Updated the Shuttle Bus Service Schedule to match the Figma design, and address feedback from usability testing

### Addressed Issues:
- Added from x campus to x campus over the departure text for better clarification
- Highlight relevant hours similar to the Figma design: fixed the GridLayout to match Figma design, and bus time slots, shows the past time slots in grey, the upcoming time slot in light burgundy, the next upcoming time slot in yellow, and the future time slots in white. 
- Mon-Thurs and Friday Button changes colours when selected 

### Expected:
<img width="365" alt="Screenshot 2025-03-29 at 10 03 41 PM" src="https://github.com/user-attachments/assets/ca96fc89-3464-4438-91d0-68f8f0bc95ae" />

### Result:
<img width="340" alt="Screenshot 2025-03-29 at 10 04 38 PM" src="https://github.com/user-attachments/assets/7104cc50-9f79-4194-97e8-90fb5a287c5f" />
