### PR TITLE
Select Calendar  + Fixed Calendar Issue when Switching Menu

### DIFF
--- a/app/src/main/java/minicap/concordia/campusnav/CalendarService/EventAdapter.java
+++ b/app/src/main/java/minicap/concordia/campusnav/CalendarService/EventAdapter.java
@@ -81,13 +81,18 @@ public class EventAdapter extends RecyclerView.Adapter<EventAdapter.EventViewHol
             holder.itemView.setBackgroundColor(0xFFFFE5E5); // light red
         }
 
-        // "Go to class" button → open MapsActivity
+        // "Go to class" button → open MapsActivity if there is a location, if not we hide the icon
+        String location = item.getLocation();
+        if (location.equals("No location")){
+           holder.goToClassIV.setVisibility(View.GONE);
+        } else {
+            holder.goToClassIV.setVisibility(View.VISIBLE);
         holder.goToClassIV.setOnClickListener(v -> {
             Intent intent = new Intent(v.getContext(), MapsActivity.class);
             // Pass the event's address string
             intent.putExtra("EVENT_ADDRESS", item.getLocation());
             v.getContext().startActivity(intent);
-        });
+        });}
     }
 
     private boolean isNextUpcomingEvent(int position, long now) {

--- a/app/src/main/java/minicap/concordia/campusnav/savedstates/States.java
+++ b/app/src/main/java/minicap/concordia/campusnav/savedstates/States.java
@@ -17,6 +17,8 @@ public class States {
 
     private boolean menuOpen = false;
 
+    private String selectedCalendarId;
+
     private static final States instance = new States();
 
     private States(){}
@@ -69,5 +71,12 @@ public class States {
 
     public void toggleMenu(boolean state){
         menuOpen = state;
+    }
+
+    public void setSelectedCalendarId(String calendarId) {
+        this.selectedCalendarId = calendarId;
+    }
+    public String getSelectedCalendarId() {
+        return this.selectedCalendarId;
     }
 }

--- a/app/src/main/java/minicap/concordia/campusnav/screens/ClassScheduleActivity.java
+++ b/app/src/main/java/minicap/concordia/campusnav/screens/ClassScheduleActivity.java
@@ -179,9 +179,8 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
     }
 
     /**
-     * ADDED:
      * Show the user a list of all their calendars, let them pick one,
-     * then store the selection in States and optionally fetch events again.
+     * then store the selection in States and fetch events again.
      */
     private void showCalendarSelectionDialog() {
         new Thread(() -> {
@@ -228,12 +227,11 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
 
                 for (int i = 0; i < calendarEntries.size(); i++) {
                     CalendarListEntry entry = calendarEntries.get(i);
-                    calendarNames[i] = entry.getSummary(); // e.g. "My Classes"
-                    calendarIds[i] = entry.getId();        // e.g. "abc123@group.calendar.google.com"
+                    calendarNames[i] = entry.getSummary();
+                    calendarIds[i] = entry.getId();
                 }
 
                 runOnUiThread(() -> {
-                    // Show a simple AlertDialog with the list of calendar names
                     new androidx.appcompat.app.AlertDialog.Builder(this)
                             .setTitle("Choose a calendar")
                             .setItems(calendarNames, (dialog, which) -> {
@@ -242,8 +240,6 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
                                 Toast.makeText(this,
                                         "Selected: " + calendarNames[which],
                                         Toast.LENGTH_SHORT).show();
-
-                                // You could automatically re-fetch events
                                 fetchCalendarEvents();
                             })
                             .show();

--- a/app/src/main/java/minicap/concordia/campusnav/screens/ClassScheduleActivity.java
+++ b/app/src/main/java/minicap/concordia/campusnav/screens/ClassScheduleActivity.java
@@ -34,6 +34,8 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.calendar.CalendarScopes;
+import com.google.api.services.calendar.model.CalendarList;
+import com.google.api.services.calendar.model.CalendarListEntry;
 import com.google.api.services.calendar.model.Event;
 import com.google.api.services.calendar.model.Events;
 
@@ -43,7 +45,7 @@ import java.util.Collections;
 import java.util.List;
 
 
-public class ClassScheduleActivity extends FragmentActivity implements MainMenuDialog.MainMenuListener{
+public class ClassScheduleActivity extends FragmentActivity implements MainMenuDialog.MainMenuListener {
 
     private static final int RC_SIGN_IN = 100;
     private static final int REQUEST_CALENDAR_PERMISSION = 101;
@@ -70,8 +72,7 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
         // Keep a reference so we can update it after fetching
         this.eventAdapter = eventAdapter;
 
-
-        //Main Menu dialog
+        // Main Menu dialog
         ImageButton menuButton = findViewById(R.id.button_menu);
         menuButton.setOnClickListener(v -> showMainMenuDialog());
 
@@ -81,19 +82,36 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
                 .requestScopes(new com.google.android.gms.common.api.Scope("https://www.googleapis.com/auth/calendar.readonly"))
                 .build();
 
-
         googleSignInClient = GoogleSignIn.getClient(this, gso);
 
         googleSignInClient.signOut().addOnCompleteListener(task -> {
         });
 
-        // Import button to handle Google Calendar import
+        // "Import" button to handle Google Calendar import
         Button importButton = findViewById(R.id.button_import_calendar);
         importButton.setOnClickListener(v -> signIn());
+
+        // "Select Calendar" button to let user pick a different calendar
+        Button selectCalendarButton = findViewById(R.id.button_select_calendar);
+        selectCalendarButton.setOnClickListener(v -> {
+            // Must ensure user is signed in & has calendar permission first
+            if (GoogleSignIn.getLastSignedInAccount(this) == null) {
+                Toast.makeText(this, "Please Sign-In first.", Toast.LENGTH_SHORT).show();
+            } else {
+                // Make sure we have READ_CALENDAR permission
+                if (ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_CALENDAR)
+                        != PackageManager.PERMISSION_GRANTED) {
+                    ActivityCompat.requestPermissions(this,
+                            new String[]{Manifest.permission.READ_CALENDAR}, REQUEST_CALENDAR_PERMISSION);
+                } else {
+                    showCalendarSelectionDialog(); // showing the list of user calendars
+                }
+            }
+        });
     }
 
     public void showMainMenuDialog() {
-        if(!states.isMenuOpen()) {
+        if (!states.isMenuOpen()) {
             MainMenuDialog dialog = new MainMenuDialog(this);
             dialog.show();
         }
@@ -123,18 +141,24 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
     }
 
     private void requestCalendarPermission() {
-        //we are requesting the permission if it is not granted yet
-        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_CALENDAR) != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_CALENDAR}, REQUEST_CALENDAR_PERMISSION);
-        } else { //if already granted, we fetch the events
+        // we are requesting the permission if it is not granted yet
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_CALENDAR)
+                != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this,
+                    new String[]{Manifest.permission.READ_CALENDAR}, REQUEST_CALENDAR_PERMISSION);
+        } else {
+            // if already granted, we fetch the events from whichever calendar is selected
             fetchCalendarEvents();
         }
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    public void onRequestPermissionsResult(int requestCode,
+                                           @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (requestCode == REQUEST_CALENDAR_PERMISSION && grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+        if (requestCode == REQUEST_CALENDAR_PERMISSION && grantResults.length > 0
+                && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
             Toast.makeText(this, "Calendar permission granted!", Toast.LENGTH_SHORT).show();
             // we fetch the calendar events once permission is granted
             fetchCalendarEvents();
@@ -142,6 +166,87 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
             Toast.makeText(this, "Calendar permission denied", Toast.LENGTH_SHORT).show();
         }
     }
+
+    /**
+     * ADDED:
+     * Show the user a list of all their calendars, let them pick one,
+     * then store the selection in States and optionally fetch events again.
+     */
+    private void showCalendarSelectionDialog() {
+        new Thread(() -> {
+            try {
+                GoogleSignInAccount account = GoogleSignIn.getLastSignedInAccount(this);
+                if (account == null) {
+                    runOnUiThread(() ->
+                            Toast.makeText(this, "Not signed in!", Toast.LENGTH_SHORT).show()
+                    );
+                    return;
+                }
+
+                // Build credential
+                GoogleAccountCredential credential = GoogleAccountCredential.usingOAuth2(
+                        this,
+                        Collections.singleton(CalendarScopes.CALENDAR_READONLY)
+                );
+                credential.setSelectedAccount(account.getAccount());
+
+                // Create the Calendar service
+                com.google.api.services.calendar.Calendar service =
+                        new com.google.api.services.calendar.Calendar.Builder(
+                                new NetHttpTransport(),
+                                GsonFactory.getDefaultInstance(),
+                                credential
+                        )
+                                .setApplicationName("CampusNav")
+                                .build();
+
+                // Get list of calendars
+                CalendarList calendarList = service.calendarList().list().execute();
+                List<CalendarListEntry> calendarEntries = calendarList.getItems();
+
+                if (calendarEntries == null || calendarEntries.isEmpty()) {
+                    runOnUiThread(() ->
+                            Toast.makeText(this, "No calendars found.", Toast.LENGTH_SHORT).show()
+                    );
+                    return;
+                }
+
+                // Build arrays for calendar names & IDs
+                String[] calendarNames = new String[calendarEntries.size()];
+                String[] calendarIds = new String[calendarEntries.size()];
+
+                for (int i = 0; i < calendarEntries.size(); i++) {
+                    CalendarListEntry entry = calendarEntries.get(i);
+                    calendarNames[i] = entry.getSummary(); // e.g. "My Classes"
+                    calendarIds[i] = entry.getId();        // e.g. "abc123@group.calendar.google.com"
+                }
+
+                runOnUiThread(() -> {
+                    // Show a simple AlertDialog with the list of calendar names
+                    new androidx.appcompat.app.AlertDialog.Builder(this)
+                            .setTitle("Choose a calendar")
+                            .setItems(calendarNames, (dialog, which) -> {
+                                // Store in States
+                                states.setSelectedCalendarId(calendarIds[which]);
+                                Toast.makeText(this,
+                                        "Selected: " + calendarNames[which],
+                                        Toast.LENGTH_SHORT).show();
+
+                                // You could automatically re-fetch events
+                                fetchCalendarEvents();
+                            })
+                            .show();
+                });
+
+            } catch (Exception e) {
+                runOnUiThread(() ->
+                        Toast.makeText(this, "Error fetching calendar list: " + e.getMessage(),
+                                Toast.LENGTH_LONG).show()
+                );
+            }
+        }).start();
+    }
+
     private void fetchCalendarEvents() {
         // Show a quick toast or progress
         Toast.makeText(this, "Fetching calendar events...", Toast.LENGTH_SHORT).show();
@@ -165,18 +270,25 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
                 credential.setSelectedAccount(account.getAccount());
 
                 // 3. Create the Calendar service
-                com.google.api.services.calendar.Calendar service = new com.google.api.services.calendar.Calendar.Builder(
-                        new NetHttpTransport(),
-                        GsonFactory.getDefaultInstance(),
-                        credential
-                )
-                        .setApplicationName("CampusNav")
-                        .build();
+                com.google.api.services.calendar.Calendar service =
+                        new com.google.api.services.calendar.Calendar.Builder(
+                                new NetHttpTransport(),
+                                GsonFactory.getDefaultInstance(),
+                                credential
+                        )
+                                .setApplicationName("CampusNav")
+                                .build();
 
-                // 4. Fetch events from the primary calendar
-                Events events = service.events().list("primary")
-                        .setMaxResults(10) // max 10 events at a time for performance purposes
-                        .setTimeMin(new DateTime(System.currentTimeMillis())) // we are just fetching events that are taking place now and in the future (we don't want past events)
+                // ADDED: Use the selected calendar ID if available, otherwise "primary"
+                String calendarId = states.getSelectedCalendarId();
+                if (calendarId == null) {
+                    calendarId = "primary";
+                }
+
+                // 4. Fetch events from that calendar
+                Events events = service.events().list(calendarId)
+                        .setMaxResults(10)
+                        .setTimeMin(new DateTime(System.currentTimeMillis()))
                         .setOrderBy("startTime")
                         .setSingleEvents(true)
                         .execute();
@@ -184,7 +296,8 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
                 List<Event> items = events.getItems();
                 if (items == null || items.isEmpty()) {
                     runOnUiThread(() ->
-                            Toast.makeText(this, "No upcoming events found.", Toast.LENGTH_SHORT).show()
+                            Toast.makeText(this, "No upcoming events found.",
+                                    Toast.LENGTH_SHORT).show()
                     );
                     return;
                 }
@@ -192,20 +305,20 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
                 // 5. Convert them to EventItem objects
                 List<EventItem> eventItemList = new ArrayList<>();
                 for (Event event : items) {
-                    String title = event.getSummary() != null ? event.getSummary() : "Untitled";
-                    String location = event.getLocation() != null ? event.getLocation() : "No location";
+                    String title = event.getSummary() != null ?
+                            event.getSummary() : "Untitled";
+                    String location = event.getLocation() != null ?
+                            event.getLocation() : "No location";
 
                     // Handle date/time
                     DateTime start = event.getStart().getDateTime();
                     DateTime end   = event.getEnd().getDateTime();
-
                     if (start == null) {
                         start = event.getStart().getDate();
                     }
                     if (end == null) {
                         end = event.getEnd().getDate();
                     }
-
 
                     eventItemList.add(new EventItem(title, location, start, end));
                 }
@@ -219,7 +332,8 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
 
             } catch (Exception e) {
                 runOnUiThread(() ->
-                        Toast.makeText(this, "Error fetching events: " + e.getMessage(), Toast.LENGTH_LONG).show()
+                        Toast.makeText(this, "Error fetching events: " + e.getMessage(),
+                                Toast.LENGTH_LONG).show()
                 );
             }
         }).start();
@@ -234,6 +348,9 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
         return dateTime.toStringRfc3339();
     }
 
-
-
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        // If you have special handling for menu or anything else, do it here
+    }
 }

--- a/app/src/main/java/minicap/concordia/campusnav/screens/ClassScheduleActivity.java
+++ b/app/src/main/java/minicap/concordia/campusnav/screens/ClassScheduleActivity.java
@@ -56,6 +56,19 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
     private final States states = States.getInstance();
 
     @Override
+    protected void onStart() {
+        super.onStart();
+
+        GoogleSignInAccount account = GoogleSignIn.getLastSignedInAccount(this);
+        if (account != null) {
+            fetchCalendarEvents();
+        } else {
+            signIn();
+        }
+    }
+
+
+    @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_schedule);
@@ -84,8 +97,6 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
 
         googleSignInClient = GoogleSignIn.getClient(this, gso);
 
-        googleSignInClient.signOut().addOnCompleteListener(task -> {
-        });
 
         // "Import" button to handle Google Calendar import
         Button importButton = findViewById(R.id.button_import_calendar);
@@ -348,9 +359,4 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
         return dateTime.toStringRfc3339();
     }
 
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        // If you have special handling for menu or anything else, do it here
-    }
 }

--- a/app/src/main/java/minicap/concordia/campusnav/screens/ClassScheduleActivity.java
+++ b/app/src/main/java/minicap/concordia/campusnav/screens/ClassScheduleActivity.java
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 
 import android.util.Log;
+import android.view.View;
 import android.widget.Button;
 import android.widget.Toast;
 import android.widget.ImageButton;
@@ -55,15 +56,16 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
 
     private final States states = States.getInstance();
 
+    private Button importButton;
+
     @Override
     protected void onStart() {
         super.onStart();
 
         GoogleSignInAccount account = GoogleSignIn.getLastSignedInAccount(this);
         if (account != null) {
+            importButton.setVisibility(View.INVISIBLE);
             fetchCalendarEvents();
-        } else {
-            signIn();
         }
     }
 
@@ -99,7 +101,7 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
 
 
         // "Import" button to handle Google Calendar import
-        Button importButton = findViewById(R.id.button_import_calendar);
+        importButton = findViewById(R.id.button_import_calendar);
         importButton.setOnClickListener(v -> signIn());
 
         // "Select Calendar" button to let user pick a different calendar
@@ -193,7 +195,7 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
                     return;
                 }
 
-                // Build credential
+                // Building credential
                 GoogleAccountCredential credential = GoogleAccountCredential.usingOAuth2(
                         this,
                         Collections.singleton(CalendarScopes.CALENDAR_READONLY)
@@ -210,7 +212,7 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
                                 .setApplicationName("CampusNav")
                                 .build();
 
-                // Get list of calendars
+                // Getting the list of calendars
                 CalendarList calendarList = service.calendarList().list().execute();
                 List<CalendarListEntry> calendarEntries = calendarList.getItems();
 
@@ -221,7 +223,7 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
                     return;
                 }
 
-                // Build arrays for calendar names & IDs
+                // Building arrays for calendar names & IDs
                 String[] calendarNames = new String[calendarEntries.size()];
                 String[] calendarIds = new String[calendarEntries.size()];
 
@@ -255,8 +257,6 @@ public class ClassScheduleActivity extends FragmentActivity implements MainMenuD
     }
 
     private void fetchCalendarEvents() {
-        // Show a quick toast or progress
-        Toast.makeText(this, "Fetching calendar events...", Toast.LENGTH_SHORT).show();
 
         new Thread(() -> {
             try {

--- a/app/src/main/res/layout/activity_schedule.xml
+++ b/app/src/main/res/layout/activity_schedule.xml
@@ -60,17 +60,23 @@
         android:overScrollMode="always"
         android:background="@android:color/white" />
 
-    <!-- Existing footer text -->
-    <TextView
-        android:id="@+id/footer_text"
-        android:layout_width="0dp"
+
+    <!-- "Select Calendar" button using MaterialButton -->
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_select_calendar"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
         android:layout_marginBottom="16dp"
-        android:fontFamily="sans-serif-light"
+
+        android:backgroundTint="@android:color/white"
+        android:elevation="4dp"
         android:text="@string/currently_loaded_google_calendar"
-        android:textColor="@android:color/white"
-        android:textSize="14sp"
+        android:textColor="@color/concordia_red"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:cornerFamily="rounded"
+        app:iconPadding="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/button_import_calendar"
         app:layout_constraintHorizontal_bias="0"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="your_destination">Your destination</string>
     <string name="menu">Menu</string>
     <string name="class_schedule">Class Schedule</string>
-    <string name="currently_loaded_google_calendar">Currently Loaded: Google Calendar Winter 2025... @link</string>
+    <string name="currently_loaded_google_calendar">Select Calendar</string>
     <string name="import_calendar">Import</string>
     <string name="go_to_class">Go to Class</string>
     <string name="current_location">Current location</string>


### PR DESCRIPTION
### PR Summary

**1. Select Calendar**

- A new method showCalendarSelectionDialog() fetches all user calendars using the Google Calendar API.

- It displays an AlertDialog listing calendar names. When the user picks one, the corresponding calendar ID is stored in the States singleton (setSelectedCalendarId(...)), and fetchCalendarEvents() is called to load events from that selected calendar.

**2. Stay Signed In**

- The code previously signed users out on every visit (via googleSignInClient.signOut() in onCreate()), forcing them to sign in again. This was removed.

- In onStart(), the code now checks if GoogleSignIn.getLastSignedInAccount(this) returns a non-null account. If so, the user is already signed in, and fetchCalendarEvents() is triggered automatically. Otherwise, signIn() is called.

- This ensures users remain logged in across activity restarts and do not have to sign in each time.